### PR TITLE
Fix can register empty string

### DIFF
--- a/src/model/user.go
+++ b/src/model/user.go
@@ -15,8 +15,8 @@ const UserTableName = "portal-users"
 // CreateUser Create user to DynamoDB
 func CreateUser(svc *dynamodb.DynamoDB, user UserCreate) error {
 
-	if user.ID == "" || user.Email == "" || user.DisplayName == "" {
-		return errors.New("Cannot insert empty string")
+	if user.ID == "" {
+		return errors.New("required ID in user")
 	}
 
 	var item = map[string]*dynamodb.AttributeValue{
@@ -31,15 +31,24 @@ func CreateUser(svc *dynamodb.DynamoDB, user UserCreate) error {
 		},
 	}
 
-	if user.Career != nil && *user.Career != "" {
+	if user.Career != nil {
+		if *user.Career == "" {
+			*user.Career = " "
+		}
 		item["career"] = &dynamodb.AttributeValue{S: aws.String(*user.Career)}
 	}
 
-	if user.AvatarURI != nil && *user.AvatarURI != "" {
+	if user.AvatarURI != nil {
+		if *user.AvatarURI == "" {
+			*user.AvatarURI = " "
+		}
 		item["avatarUri"] = &dynamodb.AttributeValue{S: aws.String(*user.AvatarURI)}
 	}
 
-	if user.Message != nil && *user.Message != "" {
+	if user.Message != nil {
+		if *user.Message == "" {
+			*user.Message = " "
+		}
 		item["message"] = &dynamodb.AttributeValue{S: aws.String(*user.Message)}
 	}
 
@@ -112,27 +121,42 @@ func UpdateUserByID(svc *dynamodb.DynamoDB, user UserUpdate) (User, error) {
 	expressionAttributeValues := map[string]*dynamodb.AttributeValue{}
 	updateExpression := "SET "
 
-	if user.Email != nil && *user.Email != "" {
+	if user.Email != nil {
+		if *user.Email == "" {
+			*user.Message = " "
+		}
 		expressionAttributeValues[":email"] = &dynamodb.AttributeValue{S: aws.String(*user.Email)}
 		updateExpression += "email = :email, "
 	}
 
-	if user.DisplayName != nil && *user.DisplayName != "" {
+	if user.DisplayName != nil {
+		if *user.DisplayName == "" {
+			*user.DisplayName = " "
+		}
 		expressionAttributeValues[":displayName"] = &dynamodb.AttributeValue{S: aws.String(*user.DisplayName)}
 		updateExpression += "displayName = :displayName, "
 	}
 
-	if user.Career != nil && *user.Career != "" {
+	if user.Career != nil {
+		if *user.Career == "" {
+			*user.Career = " "
+		}
 		expressionAttributeValues[":career"] = &dynamodb.AttributeValue{S: aws.String(*user.Career)}
 		updateExpression += "career = :career, "
 	}
 
-	if user.AvatarURI != nil && *user.AvatarURI != "" {
+	if user.AvatarURI != nil {
+		if *user.AvatarURI == "" {
+			*user.AvatarURI = " "
+		}
 		expressionAttributeValues[":avatarUri"] = &dynamodb.AttributeValue{S: aws.String(*user.AvatarURI)}
 		updateExpression += "avatarUri = :avatarUri, "
 	}
 
-	if user.Message != nil && *user.Message != "" {
+	if user.Message != nil {
+		if *user.Message == "" {
+			*user.Message = " "
+		}
 		expressionAttributeValues[":message"] = &dynamodb.AttributeValue{S: aws.String(*user.Message)}
 		updateExpression += "message = :message, "
 	}

--- a/src/model/work.go
+++ b/src/model/work.go
@@ -16,8 +16,32 @@ const WorkTableName = "portal-works"
 // CreateWork Create work to DynamoDB
 func CreateWork(svc *dynamodb.DynamoDB, work WorkCreate) error {
 
-	if work.UserID == "" || work.Title == "" || work.ImageURI == "" && work.Description == "" && work.CreatedAt == "" {
-		return errors.New("Cannot insert empty string")
+	if work.ID == "" {
+		return errors.New("required ID in work")
+	}
+
+	if work.UserID == "" {
+		work.UserID = " "
+	}
+
+	if work.Title == "" {
+		work.Title = " "
+	}
+
+	if work.UserID == "" {
+		work.UserID = " "
+	}
+
+	if work.ImageURI == "" {
+		work.ImageURI = " "
+	}
+
+	if work.Description == "" {
+		work.Description = " "
+	}
+
+	if work.CreatedAt == "" {
+		work.CreatedAt = " "
 	}
 
 	var item = map[string]*dynamodb.AttributeValue{
@@ -114,12 +138,18 @@ func UpdateWorkByID(svc *dynamodb.DynamoDB, work WorkUpdate) (Work, error) {
 	expressionAttributeValues := map[string]*dynamodb.AttributeValue{}
 	updateExpression := "SET "
 
-	if work.UserID != nil && *work.UserID != "" {
+	if work.UserID != nil {
+		if *work.UserID == "" {
+			*work.UserID = " "
+		}
 		expressionAttributeValues[":userId"] = &dynamodb.AttributeValue{S: aws.String(*work.UserID)}
 		updateExpression += "userId = :userId, "
 	}
 
-	if work.Title != nil && *work.Title != "" {
+	if work.Title != nil {
+		if *work.Title == "" {
+			*work.Title = " "
+		}
 		expressionAttributeValues[":title"] = &dynamodb.AttributeValue{S: aws.String(*work.Title)}
 		updateExpression += "title = :title, "
 	}
@@ -129,17 +159,26 @@ func UpdateWorkByID(svc *dynamodb.DynamoDB, work WorkUpdate) (Work, error) {
 		updateExpression += "tags = :tags, "
 	}
 
-	if work.ImageURI != nil && *work.ImageURI != "" {
+	if work.ImageURI != nil {
+		if *work.ImageURI == "" {
+			*work.ImageURI = " "
+		}
 		expressionAttributeValues[":imageUri"] = &dynamodb.AttributeValue{S: aws.String(*work.ImageURI)}
 		updateExpression += "imageUri = :imageUri, "
 	}
 
-	if work.Description != nil && *work.Description != "" {
+	if work.Description != nil {
+		if *work.Description == "" {
+			*work.Description = " "
+		}
 		expressionAttributeValues[":description"] = &dynamodb.AttributeValue{S: aws.String(*work.Description)}
 		updateExpression += "description = :description, "
 	}
 
-	if work.CreatedAt != nil && *work.CreatedAt != "" {
+	if work.CreatedAt != nil {
+		if *work.CreatedAt == "" {
+			*work.CreatedAt = " "
+		}
 		expressionAttributeValues[":createdAt"] = &dynamodb.AttributeValue{N: aws.String(string(*work.CreatedAt))}
 		updateExpression += "createdAt = :createdAt, "
 	}


### PR DESCRIPTION
# Fix can register empty string
## Overview
https://github.com/is09-souzou/AppSync-Resolver-Mapping-Lambda/issues/7 の修正.
> 空文字ではなく半角スペース一つを入れて置くソリューションがあるらしい.
> https://qiita.com/naoki_koreeda/items/da0b98a323e37ce1f898
に則り修正.

## Changes
- src/model/user.go
- src/model/work.go
の修正.
引数のString型ポインタの中身が空文字だった場合半角文字をセットし登録するようになっている.

## Supplement
https://github.com/is09-souzou/portal-web/issues/12
の確実な解決.