### PR TITLE
FIX: Cannot mutation createUser bug

### DIFF
--- a/src/model/user.go
+++ b/src/model/user.go
@@ -23,12 +23,16 @@ func CreateUser(svc *dynamodb.DynamoDB, user UserCreate) error {
 		"id": {
 			S: aws.String(user.ID),
 		},
-		"email": {
-			S: aws.String(*user.Email),
-		},
 		"displayName": {
 			S: aws.String(user.DisplayName),
 		},
+	}
+
+	if user.Email != nil {
+		if *user.Email == "" {
+			*user.Email = " "
+		}
+		item["email"] = &dynamodb.AttributeValue{S: aws.String(*user.Email)}
 	}
 
 	if user.Career != nil {
@@ -123,7 +127,7 @@ func UpdateUserByID(svc *dynamodb.DynamoDB, user UserUpdate) (User, error) {
 
 	if user.Email != nil {
 		if *user.Email == "" {
-			*user.Message = " "
+			*user.Email = " "
 		}
 		expressionAttributeValues[":email"] = &dynamodb.AttributeValue{S: aws.String(*user.Email)}
 		updateExpression += "email = :email, "


### PR DESCRIPTION
# FIX: Cannot mutation createUser bug
## Overview
#11 の修正.
#10 の際にEmailを必須項目から任意項目に変えた際に、pointerの中身がnilを想定した処理になっていなかったので、その修正.
同時に `UpdateUserByID` 関数のEmail代入先のバグも修正.

## Changes
- src/model/user.go