### PR TITLE
feat: works search by tags func

### DIFF
--- a/src/handler/listWork.go
+++ b/src/handler/listWork.go
@@ -36,7 +36,14 @@ func ListWorkHandle(arg ListWork, identity types.Identity) (WorkConnection, erro
 		limit = int64(*arg.Limit)
 	}
 
-	workList, err := model.ScanWorkList(svc, limit, arg.ExclusiveStartKey)
+	var workList model.ScanWorkListResult
+	if (arg.Option != nil && arg.Option.Tags != nil) {
+		fmt.Print("tags", arg.Option.Tags)
+		workList, err = model.ScanWorkListByTags(svc, limit, arg.ExclusiveStartKey, *arg.Option.Tags)
+		fmt.Print("result", workList)
+	} else {
+		workList, err = model.ScanWorkList(svc, limit, arg.ExclusiveStartKey)
+	}
 
 	if err != nil {
 		fmt.Println("Got error calling ListWorkHandle:")

--- a/src/handler/listWork.go
+++ b/src/handler/listWork.go
@@ -38,9 +38,7 @@ func ListWorkHandle(arg ListWork, identity types.Identity) (WorkConnection, erro
 
 	var workList model.ScanWorkListResult
 	if (arg.Option != nil && arg.Option.Tags != nil) {
-		fmt.Print("tags", arg.Option.Tags)
 		workList, err = model.ScanWorkListByTags(svc, limit, arg.ExclusiveStartKey, *arg.Option.Tags)
-		fmt.Print("result", workList)
 	} else {
 		workList, err = model.ScanWorkList(svc, limit, arg.ExclusiveStartKey)
 	}


### PR DESCRIPTION
# Works search by tags func
## Overview
タグ検索のエンドポイント作成.

## Changes
- src/model/work.go
ScanWorkListByTags関数を作成.
ScanWorkList関数の肥大化を抑えるために別で定義.(今後tagsとWordを含めた検索の際には再検証)

- src/handler/listWork.go
optionにtagsが含まれていた場合、ScanWorkList関数を呼び出すように変更.

## Impact range
特になし

## Operation requirement
特になし

## Supplement
デバッグ段階でデプロイ済み