### PR TITLE
Sort work list by createdAt

### DIFF
--- a/src/model/work.go
+++ b/src/model/work.go
@@ -129,10 +129,12 @@ func ScanWorkList(svc *dynamodb.DynamoDB, limit int64, exclusiveStartKey *string
 
 		KeyConditions: map[string]*dynamodb.Condition{
 			"system": {
-				AttributeValueList: []*dynamodb.AttributeValue{
-					
-				},
 				ComparisonOperator: aws.String("EQ"),
+				AttributeValueList: []*dynamodb.AttributeValue{
+					{
+						S: aws.String("work"),
+					},
+				},
 			},
 		},
 		IndexName: aws.String("system-createdAt-index"),

--- a/src/model/work.go
+++ b/src/model/work.go
@@ -137,7 +137,8 @@ func ScanWorkList(svc *dynamodb.DynamoDB, limit int64, exclusiveStartKey *string
 				},
 			},
 		},
-		IndexName: aws.String("system-createdAt-index"),
+		ScanIndexForward: aws.Bool(false),
+		IndexName:        aws.String("system-createdAt-index"),
 	}
 
 	if exclusiveStartKey != nil {


### PR DESCRIPTION
# Sort work list by createdAt
## Overview
#22
createdAtによってsortされるよう修正.

## Changes
- DynamoDB
  + GSIを追加
    * partitionKey: `system`
    * sortKey: `createdAt`
  + attributeに `system` を追加

- AppSync-Resolver-Mapping-Lambda
  + modelの変更
    * CreateWork
        - `system: "wrok"` を追加するよう変更
    * ScanWorkList/ScanWorkListByTags
        - DynamoDBAPI: `Scan` -> `Query`
        - ExclusiveStartKeyの構造変更

## Impact range
- 特になし

## Operation requirement
- 特になし
<!-- Information such as required environment variables and dependency update -->

## Supplement
- 動作確認済み
<img width="1440" alt="screen shot 2018-07-13 at 12 16 50" src="https://user-images.githubusercontent.com/19605052/42674374-677fbfa2-86aa-11e8-9868-ae0705f88f60.png">
- Deploy済み