### PR TITLE
ScanIndexForward attribute to false on model/work.go

### DIFF
--- a/src/model/work.go
+++ b/src/model/work.go
@@ -141,7 +141,7 @@ func ScanWorkList(svc *dynamodb.DynamoDB, limit int64, exclusiveStartKey *string
 			},
 		},
 		IndexName:        aws.String("system-createdAt-index"),
-		ScanIndexForward: aws.Bool(true),
+		ScanIndexForward: aws.Bool(false),
 	}
 
 	if exclusiveStartKey != nil {
@@ -241,10 +241,10 @@ func ScanWorkListByTags(svc *dynamodb.DynamoDB, limit int64, exclusiveStartKey *
 				},
 			},
 		},
-		Limit:                     &limit,
-		TableName:                 aws.String(WorkTableName),
-		IndexName:                 aws.String("system-createdAt-index"),
-		ScanIndexForward:          aws.Bool(true),
+		Limit:            &limit,
+		TableName:        aws.String(WorkTableName),
+		IndexName:        aws.String("system-createdAt-index"),
+		ScanIndexForward: aws.Bool(false),
 	}
 
 	if exclusiveStartKey != nil {


### PR DESCRIPTION
# ScanIndexForward attribute to false on model/work.go
## Overview
#22 の修正
https://github.com/is09-souzou/AppSync-Resolver-Mapping-Lambda/issues/22#issuecomment-404997665

## Changes
`ScanIndexForward: aws.Bool(true)` -> `ScanIndexForward: aws.Bool(false),`

## Impact range
- 特になし

## Operation requirement
- 特になし

## Supplement
- deploy済み
