### PR TITLE
Patch: Sort work list by createdAt

### DIFF
--- a/src/model/work.go
+++ b/src/model/work.go
@@ -291,7 +291,21 @@ func ScanWorkListByTags(svc *dynamodb.DynamoDB, limit int64, exclusiveStartKey *
 
 	var respExclusiveStartKey *string
 	if result.LastEvaluatedKey != nil {
-		respExclusiveStartKey = result.LastEvaluatedKey["id"].S
+		fmt.Print(result.LastEvaluatedKey)
+		exclusiveStartKey := ExclusiveStartKey{
+			ID:        *result.LastEvaluatedKey["id"].S,
+			CreatedAt: *result.LastEvaluatedKey["createdAt"].S,
+		}
+		byteExclusiveStartKey, err := json.Marshal(exclusiveStartKey)
+
+		if err != nil {
+			fmt.Println("Got error json Marshal exclusiveStartKey")
+			fmt.Println(err.Error())
+			return ScanWorkListResult{}, err
+		}
+
+		stringExclusiveStartKey := string(byteExclusiveStartKey)
+		respExclusiveStartKey = &stringExclusiveStartKey
 	}
 
 	return ScanWorkListResult{items, respExclusiveStartKey}, nil


### PR DESCRIPTION
# Patch: Sort work list by createdAt
## Overview
tag検索でのexclusiveStateKeyの返り値の型が異なっていたので修正.
tag検索にてtagの配列の長さが0の際にexpression build errorが発生する件の修正.

## Supplement
Deploy済み