### PR TITLE
Feat connection work endpoint

### DIFF
--- a/src/handler/workConnection.go
+++ b/src/handler/workConnection.go
@@ -1,0 +1,59 @@
+package handler
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/is09-souzou/AppSync-Resolver-Mapping-Lambda/src/model"
+	"github.com/is09-souzou/AppSync-Resolver-Mapping-Lambda/src/types"
+)
+
+// WorkConnectionArg work connection argument struct
+type WorkConnectionArg struct {
+	Limit             *int    `json:"limit"`
+	ExclusiveStartKey *string `json:"exclusiveStartKey"`
+	UserID            string  `json:"userId"`
+}
+
+// WorkConnectionHandle List Work Handle
+func WorkConnectionHandle(arg WorkConnectionArg, identity types.Identity) (WorkConnection, error) {
+
+	svc, err := model.GetSVC()
+
+	if err != nil {
+		return WorkConnection{}, err
+	}
+
+	limit := int64(10)
+	if arg.Limit != nil {
+		limit = int64(*arg.Limit)
+	}
+
+	var workList model.ScanWorkListResult
+	workList, err = model.ScanWorkListByUserID(svc, limit, arg.ExclusiveStartKey, arg.UserID)
+
+	if err != nil {
+		fmt.Println("Got error calling ListWorkHandle:")
+		fmt.Println(err.Error())
+		return WorkConnection{}, err
+	}
+
+	items := []Work{}
+
+	for _, i := range workList.Items {
+		item := Work{}
+
+		item.ID = i.ID
+		item.UserID = i.UserID
+		item.Title = i.Title
+		item.Tags = i.Tags
+		item.ImageURIs = i.ImageURIs
+		item.Description = i.Description
+		createdAt, _ := strconv.Atoi(i.CreatedAt)
+		item.CreatedAt = createdAt
+
+		items = append(items, item)
+	}
+
+	return WorkConnection{items, workList.ExclusiveStartKey}, nil
+}

--- a/src/model/work.go
+++ b/src/model/work.go
@@ -230,7 +230,7 @@ func ScanWorkListByTags(svc *dynamodb.DynamoDB, limit int64, exclusiveStartKey *
 
 	if len(tags) != 0 {
 		var filt expression.ConditionBuilder
-	
+
 		for i, x := range tags {
 			if i == 0 {
 				filt = expression.Name("tags").Contains(x)
@@ -238,16 +238,110 @@ func ScanWorkListByTags(svc *dynamodb.DynamoDB, limit int64, exclusiveStartKey *
 				filt = filt.And(expression.Name("tags").Contains(x))
 			}
 		}
-	
+
 		expr, err := expression.NewBuilder().WithFilter(filt).Build()
 
 		if err != nil {
 			return ScanWorkListResult{}, err
 		}
-		
-		params.ExpressionAttributeNames  = expr.Names();
-		params.ExpressionAttributeValues = expr.Values();
-		params.FilterExpression          = expr.Filter();
+
+		params.ExpressionAttributeNames = expr.Names()
+		params.ExpressionAttributeValues = expr.Values()
+		params.FilterExpression = expr.Filter()
+	}
+
+	if exclusiveStartKey != nil {
+
+		jsonBytes := ([]byte)(*exclusiveStartKey)
+
+		var key ExclusiveStartKey
+		json.Unmarshal(jsonBytes, &key)
+
+		params.ExclusiveStartKey = map[string]*dynamodb.AttributeValue{
+			"id": {
+				S: aws.String(key.ID),
+			},
+			"createdAt": {
+				S: aws.String(key.CreatedAt),
+			},
+			"system": {
+				S: aws.String("work"),
+			},
+		}
+	}
+
+	result, err := svc.Query(params)
+
+	if err != nil {
+		return ScanWorkListResult{}, err
+	}
+
+	items := []Work{}
+
+	for _, i := range result.Items {
+		item := Work{}
+
+		err := dynamodbattribute.UnmarshalMap(i, &item)
+
+		if err != nil {
+			fmt.Println("Got error unmarshalling:")
+			fmt.Println(err.Error())
+			return ScanWorkListResult{}, err
+		}
+
+		items = append(items, item)
+	}
+
+	var respExclusiveStartKey *string
+	if result.LastEvaluatedKey != nil {
+		fmt.Print(result.LastEvaluatedKey)
+		exclusiveStartKey := ExclusiveStartKey{
+			ID:        *result.LastEvaluatedKey["id"].S,
+			CreatedAt: *result.LastEvaluatedKey["createdAt"].S,
+		}
+		byteExclusiveStartKey, err := json.Marshal(exclusiveStartKey)
+
+		if err != nil {
+			fmt.Println("Got error json Marshal exclusiveStartKey")
+			fmt.Println(err.Error())
+			return ScanWorkListResult{}, err
+		}
+
+		stringExclusiveStartKey := string(byteExclusiveStartKey)
+		respExclusiveStartKey = &stringExclusiveStartKey
+	}
+
+	return ScanWorkListResult{items, respExclusiveStartKey}, nil
+}
+
+// ScanWorkListByUserID Scan work list By User ID from DynamoDB
+func ScanWorkListByUserID(svc *dynamodb.DynamoDB, limit int64, exclusiveStartKey *string, userID string) (ScanWorkListResult, error) {
+
+	filt := expression.Name("userId").Contains(userID)
+	expr, err := expression.NewBuilder().WithFilter(filt).Build()
+
+	if err != nil {
+		return ScanWorkListResult{}, err
+	}
+
+	params := &dynamodb.QueryInput{
+		ExpressionAttributeNames:  expr.Names(),
+		ExpressionAttributeValues: expr.Values(),
+		FilterExpression:          expr.Filter(),
+		KeyConditions: map[string]*dynamodb.Condition{
+			"system": {
+				ComparisonOperator: aws.String("EQ"),
+				AttributeValueList: []*dynamodb.AttributeValue{
+					{
+						S: aws.String("work"),
+					},
+				},
+			},
+		},
+		Limit:            &limit,
+		TableName:        aws.String(WorkTableName),
+		IndexName:        aws.String("system-createdAt-index"),
+		ScanIndexForward: aws.Bool(false),
 	}
 
 	if exclusiveStartKey != nil {

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -41,6 +41,11 @@ func Router(payload types.Payload) (interface{}, error) {
 		var p handler.WorkUpdate
 		json.Unmarshal(payload.Arguments, &p)
 		return handler.UpdateWorkHandle(p, payload.Identity)
+	// GraphQL User
+	case "connectionWork":
+		var p handler.WorkConnectionArg
+		json.Unmarshal(payload.Arguments, &p)
+		return handler.WorkConnectionHandle(p, payload.Identity)
 	}
 	return nil, errors.New("field is not found")
 }


### PR DESCRIPTION
# Feat connection work endpoint
## Overview
#26 
AppSync-Test作ってたらこのバグに気づいて思い出したので作成.

https://github.com/is09-souzou/AppSync-Resolver-Mapping-Lambda/issues/26#issue-341293711
> AppSync側だけでも実装できなくはないが、exclusiveStartKey の中身が異なってしまうためLambdaで制御する.

User専用のwork connectionにしないように設計。

## Changes
- router.go
  + 受け取りfieldに `connectionWork` を追加
- handler/workConnection.go
  + handler作成
  + 網羅テストはしてないです。今後します.
  + argの型名が `WorkConnection` だと衝突するので `WorkConnectionArg` にしてます.
- src/model/work.go
  + userIDから検索する関数を追加.

## Impact range
- 全体

## Operation requirement
- 特になし
- でも僕の開発環境でのGoのversionを1.10.3にしたので何かあったら教えてください.

## Supplement
今後 src/model/work.go をどうにかするかも.