### PR TITLE
[WIP] Feat Popular Tag and Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,39 @@
 /main
 /handler.zip
 /vendor
+/.vendor-new
 
 # Created by https://www.gitignore.io/api/go,vim,serverless,visualstudiocode
+# Created by https://www.gitignore.io/api/macos
+# Edit at https://www.gitignore.io/?templates=macos
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
 
 ### Go ###
 # Binaries for programs and plugins

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,16 +2,19 @@
 
 
 [[projects]]
+  digest = "1:7637de64e2bad97a7b9d1665e9cb0f9b709b1ef28d09232da908ead542bf89f0"
   name = "github.com/aws/aws-lambda-go"
   packages = [
     "lambda",
     "lambda/messages",
-    "lambdacontext"
+    "lambdacontext",
   ]
+  pruneopts = "UT"
   revision = "4d30d0ff60440c2d0480a15747c96ee71c3c53d4"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:140b20902771c8b582e8e50c452d85a85b8f427564f4b8369e0471ca4cae090e"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -44,54 +47,63 @@
     "service/dynamodb",
     "service/dynamodb/dynamodbattribute",
     "service/dynamodb/expression",
-    "service/sts"
+    "service/sts",
   ]
+  pruneopts = "UT"
   revision = "e4805606f5138247510183050abe642344275ebd"
   version = "v1.14.10"
 
 [[projects]]
+  digest = "1:fb46255681497314debedde38b64be32a75bae50bad107586c22f1662bf2d352"
   name = "github.com/go-ini/ini"
   packages = ["."]
+  pruneopts = "UT"
   revision = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5"
   version = "v1.37.0"
 
 [[projects]]
+  digest = "1:8f8811f9be822914c3a25c6a071e93beb4c805d7b026cbf298bc577bc1cc945b"
   name = "github.com/google/uuid"
   packages = ["."]
+  pruneopts = "UT"
   revision = "064e2069ce9c359c118179501254f67d7d37ba24"
   version = "0.2"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/is09-souzou/AppSync-Resolver-Mapping-Lambda"
-  packages = [
-    "src/handler",
-    "src/model",
-    "src/router",
-    "src/types"
-  ]
-  revision = "8f55c416f6c1d7562f1f88254331b56a825c2ecb"
-
-[[projects]]
+  digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0b12d6b5"
 
 [[projects]]
   branch = "master"
+  digest = "1:76ee51c3f468493aff39dbacc401e8831fbb765104cbf613b89bef01cf4bad70"
   name = "golang.org/x/net"
   packages = ["context"]
+  pruneopts = "UT"
   revision = "db08ff08e8622530d9ed3a0e8ac279f6d4c02196"
 
 [[projects]]
   branch = "master"
+  digest = "1:39ebcc2b11457b703ae9ee2e8cca0f68df21969c6102cb3b705f76cca0ea0239"
   name = "golang.org/x/sync"
   packages = ["errgroup"]
+  pruneopts = "UT"
   revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b666d97b0aa15031ab75ef3f49117ac161eaf44460c6ddccfcc4494c71bc0166"
+  input-imports = [
+    "github.com/aws/aws-lambda-go/lambda",
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/dynamodb",
+    "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute",
+    "github.com/aws/aws-sdk-go/service/dynamodb/expression",
+    "github.com/google/uuid",
+    "golang.org/x/sync/errgroup",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/src/handler/createWork.go
+++ b/src/handler/createWork.go
@@ -76,6 +76,9 @@ func CreateWorkHandle(arg WorkCreate, identity types.Identity) (Work, error) {
 		return Work{}, err
 	}
 
+	// Add tags of new work to popular tag
+	// TODO
+
 	result := Work{
 		ID:          id,
 		UserID:      arg.Work.UserID,

--- a/src/handler/createWork.go
+++ b/src/handler/createWork.go
@@ -76,9 +76,6 @@ func CreateWorkHandle(arg WorkCreate, identity types.Identity) (Work, error) {
 		return Work{}, err
 	}
 
-	// Add tags of new work to popular tag
-	// TODO
-
 	result := Work{
 		ID:          id,
 		UserID:      arg.Work.UserID,
@@ -88,6 +85,33 @@ func CreateWorkHandle(arg WorkCreate, identity types.Identity) (Work, error) {
 		Description: arg.Work.Description,
 		IsPublic:    arg.Work.IsPublic,
 		CreatedAt:   int(createdAt),
+	}
+
+	// Add or Inclement popular tags
+	if arg.Work.Tags != nil {
+		for _, i := range *arg.Work.Tags {
+			tag, err := model.GetPopularTagByName(svc, i)
+			if err != nil || tag.Name == "" {
+				if err := model.CreatePopularTag(
+					svc,
+					model.PopularTag{
+						Name:  i,
+						Count: 1,
+					},
+				); err != nil {
+					fmt.Println("Got error calling CreatePopularTag:")
+					fmt.Println(err.Error())
+					return Work{}, err
+				}
+			} else {
+				_, err := model.UpdatePopularTagByName(svc, tag)
+				if err != nil {
+					fmt.Println("Got error calling UpdatePopularTag:")
+					fmt.Println(err.Error())
+					return Work{}, err
+				}
+			}
+		}
 	}
 
 	return result, nil

--- a/src/handler/deleteWork.go
+++ b/src/handler/deleteWork.go
@@ -33,6 +33,20 @@ func DeleteWorkHandle(arg WorkDelete, identity types.Identity) (Work, error) {
 		return Work{}, errors.New("Can delete only oneself")
 	}
 
+	// Delete popular tags
+	if work.Tags != nil {
+		for _, i := range *work.Tags {
+			tag, err := model.GetPopularTagByName(svc, i)
+			if err != nil || tag.Name == "" {
+				if err := model.DeletePopularTagByName(svc, i); err != nil {
+					fmt.Println("Got error calling DeletePopularTag:")
+					fmt.Println(err.Error())
+					return Work{}, err
+				}
+			}
+		}
+	}
+
 	err = model.DeleteWorkByID(svc, arg.ID)
 
 	if err != nil {

--- a/src/handler/listUser.go
+++ b/src/handler/listUser.go
@@ -17,7 +17,7 @@ type ListUser struct {
 
 // UserQueryOption user query option struct
 type UserQueryOption struct {
-	UserID *string   `json:"userId"`
+	UserID *string `json:"userId"`
 }
 
 // ListUserHandle List User Handle

--- a/src/handler/listUser.go
+++ b/src/handler/listUser.go
@@ -1,0 +1,65 @@
+package handler
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/is09-souzou/AppSync-Resolver-Mapping-Lambda/src/model"
+	"github.com/is09-souzou/AppSync-Resolver-Mapping-Lambda/src/types"
+)
+
+// ListUser list user struct
+type ListUser struct {
+	Limit             *int             `json:"limit"`
+	ExclusiveStartKey *string          `json:"exclusiveStartKey"`
+	Option            *UserQueryOption `json:"option"`
+}
+
+// UserQueryOption user query option struct
+type UserQueryOption struct {
+	UserID *string   `json:"userId"`
+}
+
+// ListUserHandle List User Handle
+func ListUserHandle(arg ListUser, identity types.Identity) (UserConnection, error) {
+
+	svc, err := model.GetSVC()
+
+	if err != nil {
+		return UserConnection{}, err
+	}
+
+	limit := int64(10)
+	if arg.Limit != nil {
+		limit = int64(*arg.Limit)
+	}
+
+	var userList model.ScanUserListResult
+	userList, err = model.ScanUserList(svc, limit, arg.ExclusiveStartKey)
+
+	if err != nil {
+		fmt.Println("Got error calling ListUserHandle:")
+		fmt.Println(err.Error())
+		return UserConnection{}, err
+	}
+
+	items := []User{}
+
+	for _, i := range userList.Items {
+		item := User{}
+
+		item.ID = i.ID
+		item.AvatarURI = i.AvatarURI
+		item.Career = i.Career
+		item.DisplayName = i.DisplayName
+		item.Email = i.Email
+		item.Message = i.Message
+		item.SkillList = i.SkillList
+		createdAt, _ := strconv.Atoi(i.CreatedAt)
+		item.CreatedAt = createdAt
+
+		items = append(items, item)
+	}
+
+	return UserConnection{items, userList.ExclusiveStartKey}, nil
+}

--- a/src/handler/user.go
+++ b/src/handler/user.go
@@ -9,6 +9,7 @@ type User struct {
 	AvatarURI   *string  `json:"avatarUri"`
 	Message     *string  `json:"message"`
 	SkillList   []string `json:"skillList"`
+	CreatedAt   int      `json:"createdAt"`
 }
 
 // UserConnection response user connection struct

--- a/src/handler/user.go
+++ b/src/handler/user.go
@@ -10,3 +10,9 @@ type User struct {
 	Message     *string  `json:"message"`
 	SkillList   []string `json:"skillList"`
 }
+
+// UserConnection response user connection struct
+type UserConnection struct {
+	Items             []User  `json:"items"`
+	ExclusiveStartKey *string `json:"exclusiveStartKey"`
+}

--- a/src/handler/userConnection.go
+++ b/src/handler/userConnection.go
@@ -1,0 +1,59 @@
+package handler
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/is09-souzou/AppSync-Resolver-Mapping-Lambda/src/model"
+	"github.com/is09-souzou/AppSync-Resolver-Mapping-Lambda/src/types"
+)
+
+// UserConnectionArg user connection argument struct
+type UserConnectionArg struct {
+	Limit             *int    `json:"limit"`
+	ExclusiveStartKey *string `json:"exclusiveStartKey"`
+}
+
+// UserConnectionHandle List User Handle
+func UserConnectionHandle(arg UserConnectionArg, identity types.Identity) (UserConnection, error) {
+
+	svc, err := model.GetSVC()
+
+	if err != nil {
+		return UserConnection{}, err
+	}
+
+	limit := int64(10)
+	if arg.Limit != nil {
+		limit = int64(*arg.Limit)
+	}
+
+	var userList model.ScanUserListResult
+	userList, err = model.ScanUserList(svc, limit, arg.ExclusiveStartKey)
+
+	if err != nil {
+		fmt.Println("Got error calling ListUserHandle:")
+		fmt.Println(err.Error())
+		return UserConnection{}, err
+	}
+
+	items := []Work{}
+
+	for _, i := range userList.Items {
+		item := User{}
+
+		item.ID = i.ID
+		item.AvatarURI = i.AvatarURI
+		item.Career = i.Career
+		item.DisplayName = i.DisplayName
+		item.Email = i.Email
+		item.Message = i.Message
+		item.SkillList = i.SkillList
+		createdAt, _ := strconv.Atoi(i.CreatedAt)
+		item.CreatedAt = createdAt
+
+		items = append(items, item)
+	}
+
+	return WorkConnection{items, workList.ExclusiveStartKey}, nil
+}

--- a/src/handler/userConnection.go
+++ b/src/handler/userConnection.go
@@ -37,7 +37,7 @@ func UserConnectionHandle(arg UserConnectionArg, identity types.Identity) (UserC
 		return UserConnection{}, err
 	}
 
-	items := []Work{}
+	items := []User{}
 
 	for _, i := range userList.Items {
 		item := User{}
@@ -55,5 +55,5 @@ func UserConnectionHandle(arg UserConnectionArg, identity types.Identity) (UserC
 		items = append(items, item)
 	}
 
-	return WorkConnection{items, workList.ExclusiveStartKey}, nil
+	return UserConnection{items, userList.ExclusiveStartKey}, nil
 }

--- a/src/model/common.go
+++ b/src/model/common.go
@@ -95,23 +95,20 @@ type WorkUpdate struct {
 
 // PopularTag DynamoDB Result PopularTag Struct
 type PopularTag struct {
-	Name      string
-	Count     int
-	CreatedAt string
+	Name  string
+	Count int
 }
 
 // PopularTagCreate DynamoDB Create PopularTag Struct
 type PopularTagCreate struct {
-	Name      string
-	Count     int
-	CreatedAt string
+	Name  string
+	Count int
 }
 
 // PopularTagUpdate DynamoDB Update PopularTag Struct
 type PopularTagUpdate struct {
-	Name      string
-	Count     int
-	CreatedAt *string
+	Name  string
+	Count int
 }
 
 // ExclusiveStartKey ExclusiveStartKey for pagination

--- a/src/model/common.go
+++ b/src/model/common.go
@@ -95,22 +95,22 @@ type WorkUpdate struct {
 
 // PopularTag DynamoDB Result PopularTag Struct
 type PopularTag struct {
-	Name  string
-	Count int
+	Name      string
+	Count     int
 	CreatedAt string
 }
 
 // PopularTagCreate DynamoDB Create PopularTag Struct
 type PopularTagCreate struct {
-	Name  string
-	Count int
+	Name      string
+	Count     int
 	CreatedAt string
 }
 
 // PopularTagUpdate DynamoDB Update PopularTag Struct
 type PopularTagUpdate struct {
-	Name  string
-	Count int
+	Name      string
+	Count     int
 	CreatedAt *string
 }
 

--- a/src/model/common.go
+++ b/src/model/common.go
@@ -30,6 +30,7 @@ type User struct {
 	AvatarURI   *string
 	Message     *string
 	SkillList   []string
+	CreatedAt   string
 }
 
 // UserCreate DynamoDB Create User Struct
@@ -41,6 +42,7 @@ type UserCreate struct {
 	AvatarURI   *string
 	Message     *string
 	SkillList   []string
+	CreatedAt   string
 }
 
 // UserUpdate DynamoDB Update User Struct
@@ -52,6 +54,7 @@ type UserUpdate struct {
 	AvatarURI   *string
 	Message     *string
 	SkillList   *[]string
+	CreatedAt   *string
 }
 
 // Work DynamoDB Result Work Struct
@@ -94,18 +97,21 @@ type WorkUpdate struct {
 type PopularTag struct {
 	Name  string
 	Count int
+	CreatedAt string
 }
 
 // PopularTagCreate DynamoDB Create PopularTag Struct
 type PopularTagCreate struct {
 	Name  string
 	Count int
+	CreatedAt string
 }
 
 // PopularTagUpdate DynamoDB Update PopularTag Struct
 type PopularTagUpdate struct {
 	Name  string
 	Count int
+	CreatedAt *string
 }
 
 // ExclusiveStartKey ExclusiveStartKey for pagination

--- a/src/model/common.go
+++ b/src/model/common.go
@@ -78,7 +78,7 @@ type WorkCreate struct {
 	CreatedAt   string
 }
 
-// WorkUpdate DynamoDB Create Work Struct
+// WorkUpdate DynamoDB Update Work Struct
 type WorkUpdate struct {
 	ID          string
 	UserID      *string
@@ -88,4 +88,28 @@ type WorkUpdate struct {
 	Description *string
 	IsPublic    *bool
 	CreatedAt   *string
+}
+
+// PopularTag DynamoDB Result PopularTag Struct
+type PopularTag struct {
+	Name  string
+	Count int
+}
+
+// PopularTagCreate DynamoDB Create PopularTag Struct
+type PopularTagCreate struct {
+	Name  string
+	Count int
+}
+
+// PopularTagUpdate DynamoDB Update PopularTag Struct
+type PopularTagUpdate struct {
+	Name  string
+	Count int
+}
+
+// ExclusiveStartKey ExclusiveStartKey for pagination
+type ExclusiveStartKey struct {
+	ID        string `json:"id"`
+	CreatedAt string `json:"createdAt"`
 }

--- a/src/model/popularTag.go
+++ b/src/model/popularTag.go
@@ -1,0 +1,230 @@
+package model
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+)
+
+// PopularTagTableName DynamoDB Popular Tag Table Name
+const PopularTagTableName = "portal-popular-tags"
+
+// CreatePopularTag Create popular tag to DynamoDB
+func CreatePopularTag(svc *dynamodb.DynamoDB, popularTag PopularTag) error {
+
+	if popularTag.Name == "" {
+		return errors.New("required Name in popularTag")
+	}
+
+	var item = map[string]*dynamodb.AttributeValue{
+		"name": {
+			S: aws.String(popularTag.Name),
+		},
+		"count": {
+			N: aws.String(strconv.Itoa(popularTag.Count)),
+		},
+		"system": {
+			S: aws.String("popular-tag"),
+		},
+	}
+
+	input := &dynamodb.PutItemInput{
+		Item:      item,
+		TableName: aws.String(PopularTagTableName),
+	}
+
+	_, err := svc.PutItem(input)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetPopularTagByName Get popular tag by Name from DynamoDB
+func GetPopularTagByName(svc *dynamodb.DynamoDB, name string) (PopularTag, error) {
+
+	result, err := svc.GetItem(&dynamodb.GetItemInput{
+		TableName: aws.String(PopularTagTableName),
+		Key: map[string]*dynamodb.AttributeValue{
+			"name": {
+				S: aws.String(name),
+			},
+		},
+	})
+
+	if err != nil {
+		return PopularTag{}, err
+	}
+
+	item := PopularTag{}
+
+	err = dynamodbattribute.UnmarshalMap(result.Item, &item)
+
+	if err != nil {
+		return PopularTag{}, err
+	}
+
+	return item, nil
+}
+
+// ScanPopularTagListResult result ScanPopularTagList
+type ScanPopularTagListResult struct {
+	Items             []PopularTag
+	ExclusiveStartKey *string
+}
+
+// ScanPopularTagList Scan popular tag list from DynamoDB
+func ScanPopularTagList(svc *dynamodb.DynamoDB, limit int64, exclusiveStartKey *string) (ScanPopularTagListResult, error) {
+
+	params := &dynamodb.QueryInput{
+		Limit:     &limit,
+		TableName: aws.String(PopularTagTableName),
+		KeyConditions: map[string]*dynamodb.Condition{
+			"system": {
+				ComparisonOperator: aws.String("EQ"),
+				AttributeValueList: []*dynamodb.AttributeValue{
+					{
+						S: aws.String("popular-tag"),
+					},
+				},
+			},
+		},
+		IndexName:        aws.String("system-createdAt-index"),
+		ScanIndexForward: aws.Bool(false),
+	}
+
+	if exclusiveStartKey != nil {
+
+		jsonBytes := ([]byte)(*exclusiveStartKey)
+
+		var key ExclusiveStartKey
+		json.Unmarshal(jsonBytes, &key)
+
+		params.ExclusiveStartKey = map[string]*dynamodb.AttributeValue{
+			"name": {
+				S: aws.String(key.ID),
+			},
+			"createdAt": {
+				S: aws.String(key.CreatedAt),
+			},
+			"system": {
+				S: aws.String("popular-tag"),
+			},
+		}
+	}
+
+	result, err := svc.Query(params)
+
+	if err != nil {
+		return ScanPopularTagListResult{}, err
+	}
+
+	items := []PopularTag{}
+
+	for _, i := range result.Items {
+		item := PopularTag{}
+
+		err := dynamodbattribute.UnmarshalMap(i, &item)
+
+		if err != nil {
+			fmt.Println("Got error unmarshalling:")
+			fmt.Println(err.Error())
+			return ScanPopularTagListResult{}, err
+		}
+
+		items = append(items, item)
+	}
+
+	var respExclusiveStartKey *string
+	if result.LastEvaluatedKey != nil {
+
+		exclusiveStartKey := ExclusiveStartKey{
+			ID:        *result.LastEvaluatedKey["name"].S,
+			CreatedAt: *result.LastEvaluatedKey["createdAt"].S,
+		}
+		byteExclusiveStartKey, err := json.Marshal(exclusiveStartKey)
+
+		if err != nil {
+			fmt.Println("Got error json Marshal exclusiveStartKey")
+			fmt.Println(err.Error())
+			return ScanPopularTagListResult{}, err
+		}
+
+		stringExclusiveStartKey := string(byteExclusiveStartKey)
+		respExclusiveStartKey = &stringExclusiveStartKey
+	}
+
+	return ScanPopularTagListResult{items, respExclusiveStartKey}, nil
+}
+
+// UpdatePopularTagByName Update popular tag By Name to DynamoDB
+func UpdatePopularTagByName(svc *dynamodb.DynamoDB, popularTag PopularTag) (PopularTag, error) {
+
+	if popularTag.Name == "" {
+		return PopularTag{}, errors.New("required Name in popularTag")
+	}
+
+	expressionAttributeValues := map[string]*dynamodb.AttributeValue{}
+	updateExpression := "SET "
+
+	expressionAttributeValues[":count"] = &dynamodb.AttributeValue{N: aws.String(strconv.Itoa(popularTag.Count))}
+	updateExpression += "count = :count, "
+
+	input := &dynamodb.UpdateItemInput{
+		TableName:                 aws.String(PopularTagTableName),
+		ExpressionAttributeValues: expressionAttributeValues,
+		Key: map[string]*dynamodb.AttributeValue{
+			"name": {
+				S: aws.String(popularTag.Name),
+			},
+		},
+		ReturnValues:     aws.String("ALL_NEW"),
+		UpdateExpression: aws.String(strings.TrimRight(updateExpression, ", ")),
+	}
+
+	result, err := svc.UpdateItem(input)
+
+	if err != nil {
+		return PopularTag{}, err
+	}
+
+	item := PopularTag{}
+
+	err = dynamodbattribute.UnmarshalMap(result.Attributes, &item)
+
+	if err != nil {
+		return PopularTag{}, err
+	}
+
+	return item, nil
+}
+
+// DeletePopularTagByName Delete DynamoDB popular tag By Name
+func DeletePopularTagByName(svc *dynamodb.DynamoDB, name string) error {
+
+	input := &dynamodb.DeleteItemInput{
+		Key: map[string]*dynamodb.AttributeValue{
+			"name": {
+				S: aws.String(name),
+			},
+		},
+		TableName: aws.String(PopularTagTableName),
+	}
+
+	_, err := svc.DeleteItem(input)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}

--- a/src/model/popularTag.go
+++ b/src/model/popularTag.go
@@ -21,10 +21,6 @@ func CreatePopularTag(svc *dynamodb.DynamoDB, popularTag PopularTag) error {
 	if popularTag.Name == "" {
 		return errors.New("required Name in popularTag")
 	}
-
-	if popularTag.CreatedAt == "" {
-		popularTag.CreatedAt = " "
-	}
 	var item = map[string]*dynamodb.AttributeValue{
 		"name": {
 			S: aws.String(popularTag.Name),
@@ -176,13 +172,16 @@ func UpdatePopularTagByName(svc *dynamodb.DynamoDB, popularTag PopularTag) (Popu
 	}
 
 	expressionAttributeValues := map[string]*dynamodb.AttributeValue{}
-	updateExpression := "SET "
+	updateExpression := "SET"
 
-	expressionAttributeValues[":count"] = &dynamodb.AttributeValue{N: aws.String(strconv.Itoa(popularTag.Count))}
-	updateExpression += "count = :count, "
+	expressionAttributeValues["#c"] = &dynamodb.AttributeValue{N: aws.String(strconv.Itoa(popularTag.Count))}
+	updateExpression += "#c = :#c, "
 
 	input := &dynamodb.UpdateItemInput{
-		TableName:                 aws.String(PopularTagTableName),
+		TableName: aws.String(PopularTagTableName),
+		ExpressionAttributeNames: map[string]*string{
+			"#c": aws.String("count"),
+		},
 		ExpressionAttributeValues: expressionAttributeValues,
 		Key: map[string]*dynamodb.AttributeValue{
 			"name": {

--- a/src/model/popularTag.go
+++ b/src/model/popularTag.go
@@ -22,6 +22,9 @@ func CreatePopularTag(svc *dynamodb.DynamoDB, popularTag PopularTag) error {
 		return errors.New("required Name in popularTag")
 	}
 
+	if popularTag.CreatedAt == "" {
+		popularTag.CreatedAt = " "
+	}
 	var item = map[string]*dynamodb.AttributeValue{
 		"name": {
 			S: aws.String(popularTag.Name),

--- a/src/model/work.go
+++ b/src/model/work.go
@@ -121,12 +121,6 @@ type ScanWorkListResult struct {
 	ExclusiveStartKey *string
 }
 
-// ExclusiveStartKey ExclusiveStartKey for pagination
-type ExclusiveStartKey struct {
-	ID        string `json:"id"`
-	CreatedAt string `json:"createdAt"`
-}
-
 // ScanWorkList Scan work list from DynamoDB
 func ScanWorkList(svc *dynamodb.DynamoDB, limit int64, exclusiveStartKey *string) (ScanWorkListResult, error) {
 

--- a/src/router/router.go
+++ b/src/router/router.go
@@ -16,6 +16,10 @@ func Router(payload types.Payload) (interface{}, error) {
 		var p handler.ListWork
 		json.Unmarshal(payload.Arguments, &p)
 		return handler.ListWorkHandle(p, payload.Identity)
+	case "listUsers":
+		var p handler.ListWork
+		json.Unmarshal(payload.Arguments, &p)
+		return handler.ListWorkHandle(p, payload.Identity)
 	// GraphQL Mutations
 	case "createUser":
 		var p handler.UserCreate
@@ -46,6 +50,10 @@ func Router(payload types.Payload) (interface{}, error) {
 		var p handler.WorkConnectionArg
 		json.Unmarshal(payload.Arguments, &p)
 		return handler.WorkConnectionHandle(p, payload.Identity)
+	case "connectionUser":
+		var p handler.UserConnectionArg
+		json.Unmarshal(payload.Arguments, &p)
+		return handler.UserConnectionHandle(p, payload.Identity)
 	}
 	return nil, errors.New("field is not found")
 }


### PR DESCRIPTION
# Feat Popular Tag and Refactor
## Overview
- getPopularTags Queryの検索結果数を制限する
- ClientからMutation CreateWorkが実行され、結果を返却する際に、DynamoDBのPopular Tags tableへと結果の作品に付与されたTagを挿入(すでにタグが存在した場合は更新)する。

## Changes
- Commentの誤字を修正
- User一覧取得のpaginationを実装
    - handlerの修正
        - userConnectionの型の追加
    - modelの修正
        - 命名の修正
        - pagination用にDBに `system(user)`, `createdAt` カラムを追加
            - AppSync上のUserの型に `createdAt` カラムを追加する必要あり
- Popular Tagの実装
    - modelの追加
    - handlerの追加
    - pagination用にDBに `system(user)`, `createdAt` カラムを追加
        - AppSync上のPopular Tagの型に `createdAt` カラムを追加する必要あり
    - 注: AppSyncからの呼び出しは現状未想定

## Impact range
<!-- Affected files, functions, displays, etc. -->

## Operation requirement
<!-- Information such as required environment variables and dependency update -->
- 現状すべて中途半端
- 動作確認はまだ行っていない。
- AppSync(Lambdaを含む)でstaging環境は用意していないので、Testの際はバックアップの確保と時間の配慮を行う

## Supplement
