### PR TITLE
Add deletePopularTag and updatePopularTag

### DIFF
--- a/src/handler/createWork.go
+++ b/src/handler/createWork.go
@@ -104,7 +104,7 @@ func CreateWorkHandle(arg WorkCreate, identity types.Identity) (Work, error) {
 					return Work{}, err
 				}
 			} else {
-				_, err := model.UpdatePopularTagByName(svc, tag)
+				_, err := model.UpdatePopularTagByName(svc, tag, "1")
 				if err != nil {
 					fmt.Println("Got error calling UpdatePopularTag:")
 					fmt.Println(err.Error())

--- a/src/handler/deleteWork.go
+++ b/src/handler/deleteWork.go
@@ -45,7 +45,7 @@ func DeleteWorkHandle(arg WorkDelete, identity types.Identity) (Work, error) {
 	if work.Tags != nil {
 		for _, i := range *work.Tags {
 			tag, err := model.GetPopularTagByName(svc, i)
-			if err != nil || tag.Name != "" {
+			if err == nil && tag.Name != "" {
 				result, err := model.UpdatePopularTagByName(svc, tag, "-1")
 				if err != nil {
 					fmt.Println("Got error calling UpdatePopularTag:")

--- a/src/handler/deleteWork.go
+++ b/src/handler/deleteWork.go
@@ -41,7 +41,7 @@ func DeleteWorkHandle(arg WorkDelete, identity types.Identity) (Work, error) {
 		return Work{}, err
 	}
 
-	// Delete popular tags
+	// Delete or Decrement popular tags
 	if work.Tags != nil {
 		for _, i := range *work.Tags {
 			tag, err := model.GetPopularTagByName(svc, i)

--- a/src/handler/workConnection.go
+++ b/src/handler/workConnection.go
@@ -29,9 +29,9 @@ func WorkConnectionHandle(arg WorkConnectionArg, identity types.Identity) (WorkC
 		limit = int64(*arg.Limit)
 	}
 
-	var publicOnly = true;
+	var publicOnly = true
 	if arg.UserID == identity.Sub {
-		publicOnly = false;
+		publicOnly = false
 	}
 
 	var workList model.ScanWorkListResult

--- a/src/model/popularTag.go
+++ b/src/model/popularTag.go
@@ -225,5 +225,5 @@ func DeletePopularTagByName(svc *dynamodb.DynamoDB, name string) error {
 	}
 
 	return nil
-	
+
 }

--- a/src/model/popularTag.go
+++ b/src/model/popularTag.go
@@ -164,7 +164,7 @@ func ScanPopularTagList(svc *dynamodb.DynamoDB, limit int64, exclusiveStartKey *
 }
 
 // UpdatePopularTagByName Update popular tag By Name to DynamoDB
-func UpdatePopularTagByName(svc *dynamodb.DynamoDB, popularTag PopularTag) (PopularTag, error) {
+func UpdatePopularTagByName(svc *dynamodb.DynamoDB, popularTag PopularTag, count string) (PopularTag, error) {
 
 	if popularTag.Name == "" {
 		return PopularTag{}, errors.New("required Name in popularTag")
@@ -177,7 +177,7 @@ func UpdatePopularTagByName(svc *dynamodb.DynamoDB, popularTag PopularTag) (Popu
 		},
 		ExpressionAttributeValues: map[string]*dynamodb.AttributeValue{
 			":c": {
-				N: aws.String("1"),
+				N: aws.String(count),
 			},
 		},
 		Key: map[string]*dynamodb.AttributeValue{
@@ -225,5 +225,5 @@ func DeletePopularTagByName(svc *dynamodb.DynamoDB, name string) error {
 	}
 
 	return nil
-
+	
 }

--- a/src/model/work.go
+++ b/src/model/work.go
@@ -330,7 +330,6 @@ func ScanWorkListByTags(svc *dynamodb.DynamoDB, limit int64, exclusiveStartKey *
 // ScanWorkListByUserID Scan work list By User ID from DynamoDB
 func ScanWorkListByUserID(svc *dynamodb.DynamoDB, limit int64, exclusiveStartKey *string, userID string, publicOnly bool) (ScanWorkListResult, error) {
 
-
 	params := &dynamodb.QueryInput{
 		KeyConditions: map[string]*dynamodb.Condition{
 			"system": {


### PR DESCRIPTION
# 
## Overview
- deleteWork
  - 削除されたWorkに含まれているtagをデクリメント
  - デクリメントした時にcountが0になったらDynamoDBからそのtagを削除
- updateWork
  - updateする前のWorkに含まれていたtagをデクリメント
  - デクリメントした時にcountが0になったらDynamoDBからそのtagを削除
  - update後のWorkに含まれているtagをインクリメントorDynamoDBに作成

## Changes
- deleteWork.go
- updateWork.go
- popularTag.go
- `go fmt`で修正が入ったもの
  - workConnection.go
  - work.go

## Impact range

## Operation requirement

## Supplement
